### PR TITLE
update logic to set elapsed code time seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swdc-vscode",
   "displayName": "Code Time",
-  "version": "2.2.29",
+  "version": "2.2.30",
   "publisher": "softwaredotcom",
   "description": "Code Time is an open source plugin that provides programming metrics right in Visual Studio Code.",
   "author": {

--- a/src/command-helper.ts
+++ b/src/command-helper.ts
@@ -87,7 +87,7 @@ export function createCommands(
     // PROCESS KEYSTROKES NOW
     cmds.push(
         commands.registerCommand("codetime.processKeystrokeData", () => {
-            kpmController.processKeystrokeData();
+            kpmController.processKeystrokeData(true /*isUnfocus*/);
         })
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,8 +68,8 @@ export function getStatusBarItem() {
 }
 
 export function deactivate(ctx: ExtensionContext) {
-    // update the unfocused info
-    PluginDataManager.getInstance().editorUnFocusHandler();
+    // Process this window's keystroke data since the window has become unfocused/deactivated
+    commands.executeCommand("codetime.processKeystrokeData");
 
     // store the deactivate event
     tracker.trackEditorAction("editor", "deactivate");

--- a/src/model/KeystrokeStats.ts
+++ b/src/model/KeystrokeStats.ts
@@ -99,9 +99,9 @@ export default class KeystrokeStats {
   /**
    * send the payload
    */
-  async postData(sendNow: boolean = false) {
+  async postData(sendNow: boolean = false, isUnfocus: boolean = false) {
     // create the now times in case it's the secondary window and we have to wait
     const nowTimes = getNowTimes();
-    PluginDataManager.getInstance().processPayloadHandler(this, sendNow, nowTimes);
+    PluginDataManager.getInstance().processPayloadHandler(this, sendNow, nowTimes, isUnfocus);
   }
 }


### PR DESCRIPTION
the previous logic was setting the elapsed code time seconds to zero before setting it into the payload, this fixes that

it also updates the logic in setting the "unfocused" timestamp after the payload is processed as the payload is now processed when the editor is unfocused, or from the 1 minute trigger, or when the editor is deactivated. The 1 minute trigger will not update the unfocused timestamp though.