### PR TITLE
fixed multi win jwt usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "node-cache": "^5.1.0",
     "numeral": "^2.0.6",
     "open": "^6.4.0",
-    "swdc-tracker": "^1.0.18",
+    "swdc-tracker": "^1.0.19",
     "vsls": "0.3.1291"
   }
 }

--- a/src/DataController.ts
+++ b/src/DataController.ts
@@ -144,7 +144,6 @@ export async function getUserRegistrationState() {
                 if (pluginJwt && pluginJwt !== jwt) {
                     // update it
                     setItem("jwt", pluginJwt);
-                    TrackerManager.getInstance().resetJwt();
                 }
 
                 // if we need the user it's "resp.data.user"

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -201,7 +201,6 @@ export function getWorkspaceFolders(): WorkspaceFolder[] {
             let workspaceFolder = workspace.workspaceFolders[i];
             let folderUri = workspaceFolder.uri;
             if (folderUri && folderUri.fsPath) {
-                // paths.push(folderUri.fsPath);
                 folders.push(workspaceFolder);
             }
         }
@@ -777,6 +776,7 @@ export async function launchLogin(loginType = "software") {
     // user status has given up.
     const result = await getUserRegistrationState();
     if (result.loggedOn) {
+        window.showInformationMessage("You are already logged in. Please wait...");
         return;
     }
 

--- a/src/managers/KpmManager.ts
+++ b/src/managers/KpmManager.ts
@@ -87,7 +87,7 @@ export class KpmManager {
 
   /**
    * Currently not used
-   * @param event 
+   * @param event
    */
   private async _visibleRangeChangeHandler(event) {
     // scroll event check
@@ -208,16 +208,19 @@ export class KpmManager {
     if (textChangeInfo.textChangeLen > 8) {
       // it's a copy and paste event
       sourceObj.paste += 1;
+      sourceObj.charsPasted += textChangeInfo.textChangeLen;
       logEvent("Copy+Paste Incremented");
     } else if (textChangeInfo.textChangeLen < 0) {
       sourceObj.delete += 1;
       // update the overall count
       logEvent("Delete Incremented");
+      logEvent(sourceObj.delete);
     } else if (textChangeInfo.hasNonNewLineData) {
       // update the data for this fileInfo keys count
       sourceObj.add += 1;
       // update the overall count
       logEvent("KPM incremented");
+      logEvent(sourceObj.add);
     }
     // increment keystrokes by 1
     rootObj.keystrokes += 1;

--- a/src/managers/TrackerManager.ts
+++ b/src/managers/TrackerManager.ts
@@ -38,7 +38,8 @@ export class TrackerManager {
   }
 
   public async trackCodeTimeEvent(item: KeystrokeStats) {
-    if (!this.isReady()) {
+    const jwtParams = this.getJwtParams();
+    if (!this.trackerReady || !jwtParams) {
       return;
     }
 
@@ -81,7 +82,7 @@ export class TrackerManager {
         ...file_entity,
         ...projectInfo,
         ...this.pluginParams,
-        ...this.getJwtParams(),
+        ...jwtParams,
         ...this.tzOffsetParams,
         ...repoParams,
       };
@@ -91,7 +92,8 @@ export class TrackerManager {
   }
 
   public async trackUIInteraction(item: KpmItem) {
-    if (!this.isReady()) {
+    const jwtParams = this.getJwtParams();
+    if (!this.trackerReady || !jwtParams) {
       return;
     }
 
@@ -113,7 +115,7 @@ export class TrackerManager {
       ...ui_interaction,
       ...ui_element,
       ...this.pluginParams,
-      ...this.getJwtParams(),
+      ...jwtParams,
       ...this.tzOffsetParams,
     };
 
@@ -121,7 +123,8 @@ export class TrackerManager {
   }
 
   public async trackEditorAction(entity: string, type: string, event?: any) {
-    if (!this.isReady()) {
+    const jwtParams = this.getJwtParams();
+    if (!this.trackerReady || !jwtParams) {
       return;
     }
 
@@ -132,7 +135,7 @@ export class TrackerManager {
       entity,
       type,
       ...this.pluginParams,
-      ...this.getJwtParams(),
+      ...jwtParams,
       ...this.tzOffsetParams,
       ...projectParams,
       ...this.getFileParams(event, projectParams.project_directory),
@@ -144,14 +147,9 @@ export class TrackerManager {
 
   // Static attributes
 
-  isReady() {
-    const jwtParams = this.getJwtParams();
-    return jwtParams && jwtParams.jwt && this.trackerReady ? true : false;
-  }
-
   getJwtParams(): any {
     const jwt = getItem("jwt");
-    return { jwt: jwt ? jwt.split("JWT ")[1] : null };
+    return jwt ? { jwt: jwt.split("JWT ")[1] } : null;
   }
 
   getPluginParams(): any {

--- a/src/managers/TrackerManager.ts
+++ b/src/managers/TrackerManager.ts
@@ -39,7 +39,7 @@ export class TrackerManager {
 
   public async trackCodeTimeEvent(item: KeystrokeStats) {
     const jwtParams = this.getJwtParams();
-    if (!this.trackerReady || !jwtParams) {
+    if (!this.trackerReady || !jwtParams.jwt) {
       return;
     }
 
@@ -92,8 +92,8 @@ export class TrackerManager {
   }
 
   public async trackUIInteraction(item: KpmItem) {
-    const jwtParams = this.getJwtParams();
-    if (!this.trackerReady || !jwtParams) {
+    // ui interaction doesn't require a jwt, no need to check for that here
+    if (!this.trackerReady) {
       return;
     }
 
@@ -115,7 +115,7 @@ export class TrackerManager {
       ...ui_interaction,
       ...ui_element,
       ...this.pluginParams,
-      ...jwtParams,
+      ...this.getJwtParams(),
       ...this.tzOffsetParams,
     };
 
@@ -124,7 +124,7 @@ export class TrackerManager {
 
   public async trackEditorAction(entity: string, type: string, event?: any) {
     const jwtParams = this.getJwtParams();
-    if (!this.trackerReady || !jwtParams) {
+    if (!this.trackerReady || !jwtParams.jwt) {
       return;
     }
 
@@ -148,8 +148,7 @@ export class TrackerManager {
   // Static attributes
 
   getJwtParams(): any {
-    const jwt = getItem("jwt");
-    return jwt ? { jwt: jwt.split("JWT ")[1] } : null;
+    return { jwt: getItem("jwt")?.split("JWT ")[1] };
   }
 
   getPluginParams(): any {

--- a/src/managers/TrackerManager.ts
+++ b/src/managers/TrackerManager.ts
@@ -38,8 +38,7 @@ export class TrackerManager {
   }
 
   public async trackCodeTimeEvent(item: KeystrokeStats) {
-    const jwtParams = this.getJwtParams();
-    if (!this.trackerReady || !jwtParams.jwt) {
+    if (!this.trackerReady) {
       return;
     }
 
@@ -82,7 +81,7 @@ export class TrackerManager {
         ...file_entity,
         ...projectInfo,
         ...this.pluginParams,
-        ...jwtParams,
+        ...this.getJwtParams(),
         ...this.tzOffsetParams,
         ...repoParams,
       };
@@ -123,8 +122,7 @@ export class TrackerManager {
   }
 
   public async trackEditorAction(entity: string, type: string, event?: any) {
-    const jwtParams = this.getJwtParams();
-    if (!this.trackerReady || !jwtParams.jwt) {
+    if (!this.trackerReady) {
       return;
     }
 
@@ -135,7 +133,7 @@ export class TrackerManager {
       entity,
       type,
       ...this.pluginParams,
-      ...jwtParams,
+      ...this.getJwtParams(),
       ...this.tzOffsetParams,
       ...projectParams,
       ...this.getFileParams(event, projectParams.project_directory),

--- a/src/managers/TrackerManager.ts
+++ b/src/managers/TrackerManager.ts
@@ -13,7 +13,6 @@ export class TrackerManager {
 
   private trackerReady: boolean = false;
   private pluginParams: any = this.getPluginParams();
-  private tzOffsetParams: any = this.getTzOffsetParams();
 
   private constructor() { }
 
@@ -53,17 +52,16 @@ export class TrackerManager {
     for await (let file of fileKeys) {
       const fileData: FileChangeInfo = item.source[file];
 
-      // missing "chars_pasted"
       const codetime_entity = {
         keystrokes: fileData.keystrokes,
         chars_added: fileData.add,
         chars_deleted: fileData.delete,
+        chars_pasted: fileData.charsPasted,
         pastes: fileData.paste,
         lines_added: fileData.linesAdded,
         lines_deleted: fileData.linesRemoved,
         start_time: moment.unix(fileData.start).utc().format(),
         end_time: moment.unix(fileData.end).utc().format(),
-        tz_offset_minutes: this.tzOffsetParams.tz_offset_minutes,
       };
 
       const file_entity = {
@@ -82,7 +80,6 @@ export class TrackerManager {
         ...projectInfo,
         ...this.pluginParams,
         ...this.getJwtParams(),
-        ...this.tzOffsetParams,
         ...repoParams,
       };
 
@@ -115,7 +112,6 @@ export class TrackerManager {
       ...ui_element,
       ...this.pluginParams,
       ...this.getJwtParams(),
-      ...this.tzOffsetParams,
     };
 
     swdcTracker.trackUIInteraction(ui_event);
@@ -134,7 +130,6 @@ export class TrackerManager {
       type,
       ...this.pluginParams,
       ...this.getJwtParams(),
-      ...this.tzOffsetParams,
       ...projectParams,
       ...this.getFileParams(event, projectParams.project_directory),
       ...repoParams,
@@ -155,10 +150,6 @@ export class TrackerManager {
       plugin_name: getPluginName(),
       plugin_version: getVersion(),
     };
-  }
-
-  getTzOffsetParams(): any {
-    return { tz_offset_minutes: moment.parseZone(moment().local()).utcOffset() };
   }
 
   // Dynamic attributes

--- a/src/menu/AccountManager.ts
+++ b/src/menu/AccountManager.ts
@@ -122,7 +122,6 @@ export async function createAnonymousUser() {
             );
             if (isResponseOk(resp) && resp.data && resp.data.jwt) {
                 setItem("jwt", resp.data.jwt);
-                TrackerManager.getInstance().resetJwt();
                 return resp.data.jwt;
             }
         }

--- a/src/model/models.ts
+++ b/src/model/models.ts
@@ -51,6 +51,7 @@ export class FileChangeInfo {
   add: number = 0;
   netkeys: number = 0;
   paste: number = 0;
+  charsPasted: number = 0;
   open: number = 0;
   close: number = 0;
   delete: number = 0;

--- a/src/repo/KpmRepoManager.ts
+++ b/src/repo/KpmRepoManager.ts
@@ -66,18 +66,15 @@ export async function getFileContributorCount(fileName) {
         return 0;
     }
 
-    const projectDir = getProjectDir(fileName);
-    if (!projectDir || !isGitProject(projectDir)) {
+    const directory = getProjectDir(fileName);
+    if (!directory || !isGitProject(directory)) {
         return 0;
     }
-
-    // all we need is the filename of the path
-    // const baseName = path.basename(fileName);
 
     const cmd = `git log --pretty="%an" ${fileName}`;
 
     // get the list of users that modified this file
-    let resultList = await getCommandResult(cmd, projectDir);
+    let resultList = await getCommandResult(cmd, directory);
     if (!resultList) {
         // something went wrong, but don't try to parse a null or undefined str
         return 0;
@@ -96,16 +93,19 @@ export async function getFileContributorCount(fileName) {
     return 0;
 }
 
-export async function getRepoFileCount(fileName) {
-    const projectDir = getProjectDir(fileName);
-    if (!projectDir || !isGitProject(projectDir)) {
+/**
+ * Returns the number of files in this directory
+ * @param directory 
+ */
+export async function getRepoFileCount(directory) {
+    if (!directory || !isGitProject(directory)) {
         return 0;
     }
 
     // windows doesn't support the wc -l so we'll just count the list
     let cmd = `git ls-files`;
     // get the author name and email
-    let resultList = await getCommandResult(cmd, projectDir);
+    let resultList = await getCommandResult(cmd, directory);
     if (!resultList) {
         // something went wrong, but don't try to parse a null or undefined str
         return 0;
@@ -150,12 +150,12 @@ export async function getRepoContributorInfo(
     fileName: string,
     filterOutNonEmails: boolean = true
 ): Promise<RepoContributorInfo> {
-    const projectDir = getProjectDir(fileName);
-    if (!projectDir || !isGitProject(projectDir)) {
+    const directory = getProjectDir(fileName);
+    if (!directory || !isGitProject(directory)) {
         return null;
     }
 
-    const noSpacesProjDir = projectDir.replace(/^\s+/g, "");
+    const noSpacesProjDir = directory.replace(/^\s+/g, "");
     const cacheId = `project-repo-contributor-info-${noSpacesProjDir}`;
 
     let repoContributorInfo: RepoContributorInfo = cacheMgr.get(cacheId);
@@ -167,7 +167,7 @@ export async function getRepoContributorInfo(
     repoContributorInfo = new RepoContributorInfo();
 
     // get the repo url, branch, and tag
-    let resourceInfo = await getResourceInfo(projectDir);
+    let resourceInfo = await getResourceInfo(directory);
     if (resourceInfo && resourceInfo.identifier) {
         repoContributorInfo.identifier = resourceInfo.identifier;
         repoContributorInfo.tag = resourceInfo.tag;
@@ -176,7 +176,7 @@ export async function getRepoContributorInfo(
         // username, email
         let cmd = `git log --format='%an,%ae' | sort -u`;
         // get the author name and email
-        let resultList = await getCommandResult(cmd, projectDir);
+        let resultList = await getCommandResult(cmd, directory);
         if (!resultList) {
             // something went wrong, but don't try to parse a null or undefined str
             return repoContributorInfo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3207,10 +3207,10 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-swdc-tracker@^1.0.18:
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/swdc-tracker/-/swdc-tracker-1.0.18.tgz#9c3e5f8833db0a2d5794139cf2fd054938355033"
-  integrity sha512-4Zai41DG2jfCA+eYPUH1KDeg4Q/hh/UfXX4txKmjcPYrOjrl6gH3l54hSXyu1LyKGFl0RkWxaGRmiuP3At2fLQ==
+swdc-tracker@^1.0.19:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/swdc-tracker/-/swdc-tracker-1.0.19.tgz#540ab12d8b8be6d39e4868e342a4beb682f5aedb"
+  integrity sha512-gOROXA7JAoYjxengpmntoi4KOayn7ZtScz5aEo4OwZ0XfkMpT3O10j6RmSF7OjtfkV70DtYyzCeD09drO8e3gQ==
   dependencies:
     "@types/node" "^14.0.13"
     axios "^0.19.2"


### PR DESCRIPTION
multi vscode window have their own cache which can mean the tracker manager may end up sending an incorrect jwt based on if the user onboards or switches accounts.

the testing to fetch the jwt out of the file showed it wasn't taking more than 1 to 2 milliseconds