### PR TITLE
Omit local today

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swdc-vscode",
   "displayName": "Code Time",
-  "version": "2.3.13",
+  "version": "2.3.14",
   "publisher": "softwaredotcom",
   "description": "Code Time is an open source plugin that provides programming metrics right in Visual Studio Code.",
   "author": {

--- a/src/DataController.ts
+++ b/src/DataController.ts
@@ -775,7 +775,7 @@ export async function writeCodeTimeMetricsDashboard() {
     const summaryInfoFile = getSummaryInfoFile();
 
     // write the code time metrics summary to the summaryInfo file
-    let api = `/dashboard?showMusic=false&showRank=false&linux=${isLinux()}&showToday=false`;
+    let api = `/dashboard?linux=${isLinux()}&showToday=true`;
     const result = await softwareGet(api, getItem("jwt"));
 
     if (isResponseOk(result)) {
@@ -786,44 +786,6 @@ export async function writeCodeTimeMetricsDashboard() {
 
     // create the header
     let dashboardContent = "";
-    const formattedDate = moment().format("ddd, MMM Do h:mma");
-    dashboardContent = `CODE TIME          (Last updated on ${formattedDate})`;
-    dashboardContent += "\n\n";
-
-    const todayStr = moment().format("ddd, MMM Do");
-    dashboardContent += getSectionHeader(`Today (${todayStr})`);
-
-    const codeTimeSummary: CodeTimeSummary = getCodeTimeSummary();
-
-    // get the top section of the dashboard content (today's data)
-    const sessionSummary: SessionSummary = getSessionSummaryData();
-    if (sessionSummary) {
-        const averageTimeStr = humanizeMinutes(
-            sessionSummary.averageDailyMinutes
-        );
-
-        // code time today
-        const codeTimeToday = humanizeMinutes(codeTimeSummary.codeTimeMinutes);
-        const activeCodeTimeToday = humanizeMinutes(
-            codeTimeSummary.activeCodeTimeMinutes
-        );
-
-        let liveshareTimeStr = null;
-        if (sessionSummary.liveshareMinutes) {
-            liveshareTimeStr = humanizeMinutes(sessionSummary.liveshareMinutes);
-        }
-
-        dashboardContent += getDashboardRow("Code time today", codeTimeToday);
-        dashboardContent += getDashboardRow(
-            "Active code time today",
-            activeCodeTimeToday
-        );
-        dashboardContent += getDashboardRow("90-day avg", averageTimeStr);
-        if (liveshareTimeStr) {
-            dashboardContent += getDashboardRow("Live Share", liveshareTimeStr);
-        }
-        dashboardContent += "\n";
-    }
 
     // get the summary info we just made a call for and add it to the dashboard content
     const summaryContent = fileIt.readContentFileSync(summaryInfoFile);

--- a/src/DataController.ts
+++ b/src/DataController.ts
@@ -1,5 +1,4 @@
-import { workspace, ConfigurationTarget, window, commands } from "vscode";
-
+import { workspace, window, commands } from "vscode";
 import {
     softwareGet,
     softwarePut,
@@ -21,7 +20,6 @@ import {
     getPluginId,
     getCommitSummaryFile,
     getSummaryInfoFile,
-    getSectionHeader,
     humanizeMinutes,
     getDashboardRow,
     getDashboardBottomBorder,
@@ -39,9 +37,8 @@ import {
 } from "./Util";
 import { buildWebDashboardUrl } from "./menu/MenuManager";
 import { DEFAULT_SESSION_THRESHOLD_SECONDS } from "./Constants";
-import { SessionSummary, CommitChangeStats } from "./model/models";
+import { CommitChangeStats } from "./model/models";
 import {
-    getSessionSummaryData,
     clearSessionSummaryData,
 } from "./storage/SessionSummaryData";
 import TeamMember from "./model/TeamMember";
@@ -50,9 +47,6 @@ import {
     getThisWeeksCommits,
     getYesterdaysCommits,
 } from "./repo/GitUtil";
-import CodeTimeSummary from "./model/CodeTimeSummary";
-import { getCodeTimeSummary } from "./storage/TimeSummaryData";
-import { TrackerManager } from "./managers/TrackerManager";
 import { SummaryManager } from "./managers/SummaryManager";
 
 const fileIt = require("file-it");


### PR DESCRIPTION
the "showToday" works for the current codemetrics backend, requesting it to build the today and top header section. this was set to false in the past to make the generation of this as fast as possible

https://www.loom.com/share/cbc8fdacf18346e9a35b8205bc2ce760?from_recorder=1