### PR TITLE
tree metrics updates and slack disconnect command updates

### DIFF
--- a/src/DataController.ts
+++ b/src/DataController.ts
@@ -42,7 +42,7 @@ export function getToggleFileEventLoggingState() {
   return toggleFileEventLogging;
 }
 
-export async function getUserRegistrationState(isIntegrationReq = false) {
+export async function getUserRegistrationState() {
   const jwt = getItem("jwt");
   const auth_callback_state = getAuthCallbackState();
   const authType = getItem("authType");
@@ -73,10 +73,11 @@ export async function getUserRegistrationState(isIntegrationReq = false) {
 
     // make sure we don't wipe out the jwt if its null and its the same user
     updateJwt(user.plugin_jwt);
+    if (user.plugin_jwt) {
+      setItem("jwt", user.plugin_jwt);
+    }
     if (registered === 1) {
       setItem("name", user.email);
-    } else {
-      setItem("name", null);
     }
 
     const currentAuthType = getItem("authType");

--- a/src/DataController.ts
+++ b/src/DataController.ts
@@ -21,7 +21,7 @@ import {
   setAuthCallbackState,
 } from "./Util";
 import { buildWebDashboardUrl } from "./menu/MenuManager";
-import { DEFAULT_SESSION_THRESHOLD_SECONDS } from "./Constants";
+import { DEFAULT_SESSION_THRESHOLD_SECONDS, SIGN_UP_LABEL } from "./Constants";
 import { CommitChangeStats } from "./model/models";
 import { clearSessionSummaryData } from "./storage/SessionSummaryData";
 import { getTodaysCommits, getThisWeeksCommits, getYesterdaysCommits } from "./repo/GitUtil";
@@ -228,6 +228,23 @@ async function userStatusFetchHandler(tryCountUntilFoundUser, interval) {
 }
 
 export async function launchWebDashboard() {
+  if (!getItem("name")) {
+    window
+      .showInformationMessage(
+        "Sign up or log in to see more data visualizations.",
+        {
+          modal: true,
+        },
+        SIGN_UP_LABEL
+      )
+      .then(async (selection) => {
+        if (selection === SIGN_UP_LABEL) {
+          commands.executeCommand("codetime.signUpAccount");
+        }
+      });
+    return;
+  }
+
   let webUrl = await buildWebDashboardUrl();
 
   // add the token=jwt

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -882,7 +882,7 @@ export function getFileDataArray(file) {
 
 // get the percent string dividing the reference value by the current value
 // this is meant to show the progressing percent of the daily average stats
-export function getPercentOfReferenceAvg(currentValue, referenceValue) {
+export function getPercentOfReferenceAvg(currentValue, referenceValue, referenceValueDisplay) {
   currentValue = currentValue ?? 0;
   let quotient = 1;
   if (referenceValue) {
@@ -893,5 +893,5 @@ export function getPercentOfReferenceAvg(currentValue, referenceValue) {
       quotient = 0.01;
     }
   }
-  return `${(quotient * 100).toFixed(0)}% of avg`;
+  return `${(quotient * 100).toFixed(0)}% of ${referenceValueDisplay}`;
 }

--- a/src/command-helper.ts
+++ b/src/command-helper.ts
@@ -20,6 +20,7 @@ import {
   shareSlackMessage,
   setProfileStatus,
   toggleSlackPresence,
+  disconnectSlackWorkspace,
 } from "./managers/SlackManager";
 import { vscode_issues_url } from "./Constants";
 import { CodeTimeFlowProvider, connectCodeTimeFlowTreeView } from "./tree/CodeTimeFlowProvider";
@@ -379,8 +380,12 @@ export function createCommands(
   );
 
   cmds.push(
-    commands.registerCommand("codetime.disconnectSlackWorkspace", (kptmItem: KpmItem) => {
-      disconnectSlackAuth(kptmItem.value);
+    commands.registerCommand("codetime.disconnectSlackWorkspace", (kptmItem: any) => {
+      if (kptmItem && kptmItem.value) {
+        disconnectSlackAuth(kptmItem.value);
+      } else {
+        disconnectSlackWorkspace();
+      }
     })
   );
 
@@ -416,7 +421,9 @@ export function createCommands(
 
   cmds.push(
     commands.registerCommand("codetime.toggleFullScreen", () => {
+      KpmProviderManager.getInstance().showingFullScreen = !KpmProviderManager.getInstance().showingFullScreen;
       commands.executeCommand("workbench.action.toggleFullScreen");
+      commands.executeCommand("codetime.refreshFlowTree");
     })
   );
 

--- a/src/managers/SlackManager.ts
+++ b/src/managers/SlackManager.ts
@@ -1,5 +1,5 @@
 import { commands, window } from "vscode";
-import { api_endpoint, DISCONNECT_LABEL, SIGN_UP_LABEL, YES_LABEL } from "../Constants";
+import { api_endpoint, DISCONNECT_LABEL, SIGN_UP_LABEL } from "../Constants";
 import { getUserRegistrationState } from "../DataController";
 import {
   getAuthCallbackState,
@@ -471,7 +471,7 @@ async function refetchSlackConnectStatusLazily(tryCountUntilFoundUser) {
  */
 async function getSlackAuth() {
   let foundNewIntegration = false;
-  const { user } = await getUserRegistrationState(true);
+  const { user } = await getUserRegistrationState();
   if (user && user.integrations) {
     const currentIntegrations = getIntegrations();
     // find the slack auth

--- a/src/managers/SlackManager.ts
+++ b/src/managers/SlackManager.ts
@@ -71,6 +71,20 @@ export async function connectSlackWorkspace() {
   }, 10000);
 }
 
+export async function disconnectSlackWorkspace() {
+  const registered = await checkRegistration();
+  if (!registered) {
+    return;
+  }
+  // pick the workspace to disconnect
+  const selectedTeamDomain = await showSlackWorkspaceSelection();
+
+  if (selectedTeamDomain) {
+    const slackIntegration = getSlackWorkspaces().find((n) => n.team_domain === selectedTeamDomain);
+    disconnectSlackAuth(selectedTeamDomain.authId);
+  }
+}
+
 // disconnect slack flow
 export async function disconnectSlackAuth(authId) {
   // get the domain

--- a/src/menu/AccountManager.ts
+++ b/src/menu/AccountManager.ts
@@ -141,17 +141,6 @@ export async function createAnonymousUser(ignoreJwt: boolean = false): Promise<s
   return null;
 }
 
-export function updateJwt(newJwt) {
-  if (!newJwt) {
-    return;
-  }
-  const currentJwtId = getDecodedUserIdFromJwt(getItem("jwt"));
-  const newJwtId = getDecodedUserIdFromJwt(newJwt);
-  if (newJwtId !== currentJwtId) {
-    setItem("jwt", newJwt);
-  }
-}
-
 export function getDecodedUserIdFromJwt(jwt) {
   try {
     if (jwt && jwt.includes("JWT")) {


### PR DESCRIPTION
* "Exit full screen" and "Enter full screen" updates
* added actual average in description and more info in the tooltip
* added logic to show the signup flow if clicking on the software.com item if not logged on yet
* fixed the slack disconnect option from the command palette

<img width="384" alt="Screen Shot 2021-01-03 at 5 14 35 PM" src="https://user-images.githubusercontent.com/35306917/103493691-a242c100-4de7-11eb-9c69-7fc723bc00ad.png">
