### PR TITLE
pass slack as an upgrade feature

### DIFF
--- a/src/managers/SlackManager.ts
+++ b/src/managers/SlackManager.ts
@@ -55,6 +55,7 @@ export async function connectSlackWorkspace() {
     plugin_id: getPluginId(),
     auth_callback_state: getAuthCallbackState(),
     integrate: "slack",
+    upgradeFeatures: "dnd",
     plugin_token: getItem("jwt"),
   });
 


### PR DESCRIPTION
The slack integration now supports more features, so we need to pass in a target feature flag.