### PR TITLE
cache the default branch git result and cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swdc-vscode",
   "displayName": "Code Time",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "publisher": "softwaredotcom",
   "description": "Code Time is an open source plugin that provides programming metrics right in Visual Studio Code.",
   "author": {

--- a/src/managers/PluginDataManager.ts
+++ b/src/managers/PluginDataManager.ts
@@ -16,9 +16,8 @@ import { clearFileChangeInfoSummaryData, getFileChangeSummaryAsJson, saveFileCha
 import KeystrokeStats from "../model/KeystrokeStats";
 import { UNTITLED, NO_PROJ_NAME } from "../Constants";
 import { WorkspaceFolder } from "vscode";
-import { getResourceInfo, getRepoContributorInfo, getRepoFileCount, getFileContributorCount } from "../repo/KpmRepoManager";
+import { getResourceInfo } from "../repo/KpmRepoManager";
 import Project from "../model/Project";
-import RepoContributorInfo from "../model/RepoContributorInfo";
 import { FileChangeInfo, KeystrokeAggregate } from "../model/models";
 import { WallClockManager } from "./WallClockManager";
 import TimeData from "../model/TimeData";
@@ -350,21 +349,6 @@ export class PluginDataManager {
     saveFileChangeInfoToDisk(fileChangeInfoMap);
   }
 
-  async populateRepoMetrics(payload: KeystrokeStats) {
-    if (payload.project && payload.project.identifier && payload.project.directory) {
-      // REPO contributor count
-      const repoContributorInfo: RepoContributorInfo = await getRepoContributorInfo(payload.project.directory, true);
-      payload.repoContributorCount = repoContributorInfo ? repoContributorInfo.count || 0 : 0;
-
-      // REPO file count
-      const repoFileCount = await getRepoFileCount(payload.project.directory);
-      payload.repoFileCount = repoFileCount || 0;
-    } else {
-      payload.repoContributorCount = 0;
-      payload.repoFileCount = 0;
-    }
-  }
-
   /**
    * Populate the project information for this specific payload
    * @param payload
@@ -395,8 +379,6 @@ export class PluginDataManager {
     p.resource = resourceInfo;
     p.identifier = resourceInfo?.identifier ?? "";
     payload.project = p;
-
-    await this.populateRepoMetrics(payload);
   }
 
   /**
@@ -416,12 +398,6 @@ export class PluginDataManager {
           fileInfo.local_end = nowTimes.local_now_in_sec;
         }
 
-        // only get the contributor info if we have a repo identifier
-        if (payload.project && payload.project.identifier) {
-          // set the contributor count per file
-          const repoFileContributorCount = await getFileContributorCount(key);
-          fileInfo.repoFileContributorCount = repoFileContributorCount || 0;
-        }
         payload.source[key] = fileInfo;
       }
     }

--- a/src/repo/KpmRepoManager.ts
+++ b/src/repo/KpmRepoManager.ts
@@ -32,57 +32,6 @@ function getProjectDir(fileName = null) {
   return null;
 }
 
-export async function getFileContributorCount(fileName) {
-  let fileType = getFileType(fileName);
-
-  if (fileType === "git") {
-    return 0;
-  }
-
-  const directory = getProjectDir(fileName);
-  if (!directory || !isGitProject(directory)) {
-    return 0;
-  }
-
-  const cmd = `git log --pretty="%an" ${fileName}`;
-
-  // get the list of users that modified this file
-  let resultList = execCmd(cmd, directory, true);
-
-  if (resultList?.length) {
-    let map = {};
-    for (let i = 0; i < resultList.length; i++) {
-      const name = resultList[i];
-      if (!map[name]) {
-        map[name] = name;
-      }
-    }
-    return Object.keys(map).length;
-  }
-  return 0;
-}
-
-/**
- * Returns the number of files in this directory
- * @param directory
- */
-export async function getRepoFileCount(directory) {
-  if (!directory || !isGitProject(directory)) {
-    return 0;
-  }
-
-  // windows doesn't support the wc -l so we'll just count the list
-  let cmd = `git ls-files`;
-  // get the author name and email
-  let resultList = execCmd(cmd, directory, true);
-  if (!resultList) {
-    // something went wrong, but don't try to parse a null or undefined str
-    return 0;
-  }
-
-  return resultList.length;
-}
-
 export async function getRepoContributorInfo(fileName: string, filterOutNonEmails: boolean = true): Promise<RepoContributorInfo> {
   const directory = getProjectDir(fileName);
   if (!directory || !isGitProject(directory)) {


### PR DESCRIPTION
* this caches the default branch git result for 1 day
* and removes git commands that populate the unused outgoing payload attributes

Tested with a hardcoded branch on a known debug project with a 10 second interval. The branch is cached and is used from the cache on the next fetch