### PR TITLE
sync secondary vscode windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,7 +120,7 @@ export async function intializePlugin(ctx: ExtensionContext, createdAnonUser: bo
   current_status_update_interval = setInterval(() => {
     // update with local data to keep secondary windows in sync
     updateStatusBarWithSummaryData();
-  }, 1000 * 60 * 10);
+  }, 1000 * 60 * 2);
 }
 
 export function getCurrentColorKind() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,12 +13,12 @@ import { TrackerManager } from "./managers/TrackerManager";
 import { initializeWebsockets, clearWebsocketConnectionRetryTimeout } from "./websockets";
 import { softwarePost } from "./http/HttpClient";
 import { configureSettings, showingConfigureSettingsPanel } from "./managers/ConfigManager";
-import { initializeStatusBar } from "./managers/StatusBarManager";
+import { initializeStatusBar, updateStatusBarWithSummaryData } from "./managers/StatusBarManager";
 import { SummaryManager } from "./managers/SummaryManager";
 
 let TELEMETRY_ON = true;
 let currentColorKind: number = undefined;
-let liveshare_update_interval = null;
+let current_status_update_interval = null;
 
 const tracker: TrackerManager = TrackerManager.getInstance();
 
@@ -42,7 +42,7 @@ export function deactivate(ctx: ExtensionContext) {
   // dispose the new day timer
   PluginDataManager.getInstance().dispose();
 
-  clearInterval(liveshare_update_interval);
+  clearInterval(current_status_update_interval);
 
   clearWebsocketConnectionRetryTimeout();
 }
@@ -112,6 +112,15 @@ export async function intializePlugin(ctx: ExtensionContext, createdAnonUser: bo
 
     SummaryManager.getInstance().updateSessionSummaryFromServer();
   }, 0);
+
+  if (current_status_update_interval) {
+    clearInterval(current_status_update_interval);
+  }
+
+  current_status_update_interval = setInterval(() => {
+    // update with local data to keep secondary windows in sync
+    updateStatusBarWithSummaryData();
+  }, 1000 * 60 * 10);
 }
 
 export function getCurrentColorKind() {

--- a/src/managers/SyncManger.ts
+++ b/src/managers/SyncManger.ts
@@ -1,0 +1,24 @@
+import { getSessionSummaryFile } from "../Util";
+import { updateStatusBarWithSummaryData } from "./StatusBarManager";
+const fs = require("fs");
+
+export class SyncManager {
+  private static _instance: SyncManager;
+
+  static getInstance(): SyncManager {
+    if (!SyncManager._instance) {
+      SyncManager._instance = new SyncManager();
+    }
+
+    return SyncManager._instance;
+  }
+
+  constructor() {
+    // fs.watch replaces fs.watchFile and fs.unwatchFile
+    fs.watch(getSessionSummaryFile(), (curr, prev) => {
+      if (curr === "change") {
+        updateStatusBarWithSummaryData();
+      }
+    });
+  }
+}


### PR DESCRIPTION
After testing the secondary vscode windows "status bar metrics" will not update since the current stats update event will be handled by the primary window. This will keep all windows in sync every 10 minutes by updating the status bar with the local session summary file that is updated from that event.