### PR TITLE
handle new install when initializing file watch

### DIFF
--- a/src/managers/SyncManger.ts
+++ b/src/managers/SyncManger.ts
@@ -1,5 +1,7 @@
-import { getSessionSummaryFile } from "../Util";
+import { SessionSummary } from "../model/models";
+import { getFileDataAsJson, getSessionSummaryFile } from "../Util";
 import { updateStatusBarWithSummaryData } from "./StatusBarManager";
+import { saveSessionSummaryToDisk } from "../storage/SessionSummaryData";
 const fs = require("fs");
 
 export class SyncManager {
@@ -14,8 +16,16 @@ export class SyncManager {
   }
 
   constructor() {
+    const file = getSessionSummaryFile();
+
+    // make sure the file exists before we start listening to it
+    let sessionSummary = getFileDataAsJson(file);
+    if (!sessionSummary) {
+      sessionSummary = new SessionSummary();
+      saveSessionSummaryToDisk(sessionSummary);
+    }
     // fs.watch replaces fs.watchFile and fs.unwatchFile
-    fs.watch(getSessionSummaryFile(), (curr, prev) => {
+    fs.watch(file, (curr, prev) => {
       if (curr === "change") {
         updateStatusBarWithSummaryData();
       }

--- a/src/managers/SyncManger.ts
+++ b/src/managers/SyncManger.ts
@@ -1,7 +1,7 @@
 import { SessionSummary } from "../model/models";
 import { getFileDataAsJson, getSessionSummaryFile } from "../Util";
 import { updateStatusBarWithSummaryData } from "./StatusBarManager";
-import { saveSessionSummaryToDisk } from "../storage/SessionSummaryData";
+import { getSessionSummaryFileAsJson, saveSessionSummaryToDisk } from "../storage/SessionSummaryData";
 const fs = require("fs");
 
 export class SyncManager {
@@ -16,16 +16,11 @@ export class SyncManager {
   }
 
   constructor() {
-    const file = getSessionSummaryFile();
+    // make sure the file exists
+    getSessionSummaryFileAsJson();
 
-    // make sure the file exists before we start listening to it
-    let sessionSummary = getFileDataAsJson(file);
-    if (!sessionSummary) {
-      sessionSummary = new SessionSummary();
-      saveSessionSummaryToDisk(sessionSummary);
-    }
     // fs.watch replaces fs.watchFile and fs.unwatchFile
-    fs.watch(file, (curr, prev) => {
+    fs.watch(getSessionSummaryFile(), (curr, prev) => {
       if (curr === "change") {
         updateStatusBarWithSummaryData();
       }

--- a/src/managers/SyncManger.ts
+++ b/src/managers/SyncManger.ts
@@ -1,7 +1,6 @@
-import { SessionSummary } from "../model/models";
-import { getFileDataAsJson, getSessionSummaryFile } from "../Util";
+import { getSessionSummaryFile } from "../Util";
 import { updateStatusBarWithSummaryData } from "./StatusBarManager";
-import { getSessionSummaryFileAsJson, saveSessionSummaryToDisk } from "../storage/SessionSummaryData";
+import { getSessionSummaryFileAsJson } from "../storage/SessionSummaryData";
 const fs = require("fs");
 
 export class SyncManager {

--- a/src/user/OnboardManager.ts
+++ b/src/user/OnboardManager.ts
@@ -127,7 +127,8 @@ async function getUserRegistrationInfo() {
   let resp = await softwareGet("/users/plugin/state", token);
   let user = isResponseOk(resp) && resp.data ? resp.data.user : null;
 
-  if (user) {
+  // only update if its a registered, not anon user
+  if (user && user.registered === 1) {
     await authenticationCompleteHandler(user);
     return true;
   }


### PR DESCRIPTION
the plugin will throw an alert on install if node fs.watch fails to find a file to listen to. this will create the file if it doesn't exist