### PR TITLE
remove auth type icon and allow session update

### DIFF
--- a/src/DataController.ts
+++ b/src/DataController.ts
@@ -125,41 +125,39 @@ export async function authenticationCompleteHandler(user) {
   setAuthCallbackState(null);
 
   if (user?.registered === 1) {
-    const currName = getItem("name");
-    if (currName != user.email) {
-      updatedUserInfo = true;
-      // new user
-      if (user.plugin_jwt) {
-        setItem("jwt", user.plugin_jwt);
-      }
-      setItem("name", user.email);
-
-      const currentAuthType = getItem("authType");
-      if (!currentAuthType) {
-        setItem("authType", "software");
-      }
-
-      // update the login status
-      window.showInformationMessage(`Successfully logged on to Code Time`);
-
-      updateFlowModeStatus();
-
-      try {
-        initializeWebsockets();
-      } catch (e) {
-        console.error("Failed to initialize codetime websockets", e);
-      }
-
-      // fetch any teams for this user
-      await getTeams();
-
-      clearSessionSummaryData();
-      clearTimeDataSummary();
-      // fetch after logging on
-      SummaryManager.getInstance().updateSessionSummaryFromServer();
-
-      initializePreferences();
+    updatedUserInfo = true;
+    // new user
+    if (user.plugin_jwt) {
+      setItem("jwt", user.plugin_jwt);
     }
+    setItem("name", user.email);
+
+    const currentAuthType = getItem("authType");
+    if (!currentAuthType) {
+      setItem("authType", "software");
+    }
+
+    // update the login status
+    window.showInformationMessage(`Successfully logged on to Code Time`);
+
+    updateFlowModeStatus();
+
+    try {
+      initializeWebsockets();
+    } catch (e) {
+      console.error("Failed to initialize codetime websockets", e);
+    }
+
+    // fetch any teams for this user
+    await getTeams();
+
+    clearSessionSummaryData();
+    clearTimeDataSummary();
+    // fetch after logging on
+    SummaryManager.getInstance().updateSessionSummaryFromServer();
+
+    initializePreferences();
+
     setItem("vscode_CtskipSlackConnect", false);
   }
 

--- a/src/app/views/components/account.tsx
+++ b/src/app/views/components/account.tsx
@@ -92,17 +92,6 @@ export default function Account(props) {
         <List style={{ padding: 0, margin: 0 }}>
           <ListItem style={{ padding: 0, margin: 0 }}>
             <ListItemText primary="Account" secondary={!stateData.registered ? "Manage your account" : stateData.email} />
-            <ListItemSecondaryAction classes={{ root: classes.secondaryAction }}>
-              <div aria-label="Authentication type">
-                {!stateData.registered ? null : stateData.authType === "github" ? (
-                  <GithubIcon />
-                ) : stateData.authType === "google" ? (
-                  <GoogleIcon />
-                ) : (
-                  <EmailIcon />
-                )}
-              </div>
-            </ListItemSecondaryAction>
           </ListItem>
         </List>
       </Grid>


### PR DESCRIPTION
This removes the auth type icon (google, github, email) to help alleviate account switching confusion.

<img width="306" alt="Screen Shot 2021-05-28 at 11 19 31 AM" src="https://user-images.githubusercontent.com/35306917/120026379-d725ff00-bfa6-11eb-8fec-e9eb26730864.png">
 