### PR TITLE
adapt to the server timeout or use default reconnect timeout

### DIFF
--- a/src/websockets.ts
+++ b/src/websockets.ts
@@ -8,9 +8,10 @@ import { handleCurrentDayStatsUpdate } from "./message_handlers/current_day_stat
 
 const WebSocket = require("ws");
 
-// This is the server interval to ping this client. If the server
-// interval changes, this interval should change with it to match.
-const SERVER_PING_INTERVAL_MILLIS = 1000 * 60 * 2;
+// Default to 6 minutes.
+// The server should send its timeout to allow the client to adjust.
+const ONE_MIN_MILLIS = 1000 * 60;
+let SERVER_PING_INTERVAL_MILLIS = ONE_MIN_MILLIS * 6;
 let pingTimeout = undefined;
 let retryTimeout = undefined;
 
@@ -30,7 +31,18 @@ export function initializeWebsockets() {
 
   const ws = new WebSocket(websockets_url, options);
 
-  function heartbeat() {
+  function heartbeat(buf) {
+    try {
+      // convert the buffer to the json payload containing the server timeout
+      const data = JSON.parse(buf.toString());
+      if (data?.timeout) {
+        // add a 1 minute buffer
+        SERVER_PING_INTERVAL_MILLIS = data.timeout + ONE_MIN_MILLIS;
+      }
+    } catch (e) {
+      // defaults to the 6 minutes interval
+    }
+
     if (pingTimeout) {
       // Received a ping from the server. Clear the timeout so
       // our client doesn't terminate the connection
@@ -45,12 +57,11 @@ export function initializeWebsockets() {
       if (ws) {
         ws.terminate();
       }
-    }, SERVER_PING_INTERVAL_MILLIS + 5000);
+    }, SERVER_PING_INTERVAL_MILLIS);
   }
 
   ws.on("open", function open() {
     console.debug("[CodeTime] websockets connection open");
-    heartbeat();
   });
 
   ws.on("ping", heartbeat);


### PR DESCRIPTION
The client will parse the ping buffer and use the provided timeout to set its own reconnect timeout + 1 minute