### PR TITLE
update usage of progressIt for the update settings function

### DIFF
--- a/src/command-helper.ts
+++ b/src/command-helper.ts
@@ -420,7 +420,7 @@ export function createCommands(
   // Update the settings preferences
   cmds.push(
     commands.registerCommand('codetime.updateSettings', (payload: any) => {
-      progressIt('Updating settings...', updateSettings(payload.path, payload.json));
+      progressIt('Updating settings...', updateSettings, [payload.path, payload.json]);
     })
   );
 

--- a/src/managers/ProgressManager.ts
+++ b/src/managers/ProgressManager.ts
@@ -45,10 +45,14 @@ export function progressIt(msg: string, asyncFunc: any, args: any[] = []) {
       cancellable: false,
     },
     async (progress) => {
-      if (args?.length) {
-        await asyncFunc(...args).catch((e: any) => {});
+      if (typeof asyncFunc === 'function') {
+        if (args?.length) {
+          await asyncFunc(...args).catch((e: any) => {});
+        } else {
+          await asyncFunc().catch((e: any) => {});
+        }
       } else {
-        await asyncFunc().catch((e: any) => {});
+        await asyncFunc;
       }
     }
   );


### PR DESCRIPTION
* The registered updateSettings command was providing the promise result to the "progressIt" instead of the actual function with the array of args. This fixes this issue. Its currently throwing unhandled rejection exceptions but still submitting the settings updates.