### PR TITLE
Updated FileManager.getFileDataAsJson to trim string prior parsing. (issue #387)

### DIFF
--- a/src/managers/FileManager.ts
+++ b/src/managers/FileManager.ts
@@ -19,7 +19,7 @@ export function setJsonItem(file: string, key: string, value: any) {
 
 export function getFileDataAsJson(filePath: string): any {
   try {
-    const content: string = fs.readFileSync(filePath, 'utf8').trimEnd();
+    const content: string = fs.readFileSync(filePath, 'utf8')?.trim();
     return JSON.parse(content);
   } catch (e: any) {
     logIt(`Unable to read ${getBaseName(filePath)} info: ${e.message}`, true);


### PR DESCRIPTION
After trying to debug the extension, I had the same error mentioned by [morphx666](https://github.com/morphx666) here: [#376 - Extension activation fails with error: RangeError: Maximum call stack size exceeded](https://github.com/swdotcom/swdc-vscode/issues/376#issuecomment-1033196562)

An exception was thrown on `FileManager.getFileDataAsJson()`, trying to parse a file content as a JSON, and that resulted in a loop causing the `RangeError: Maximum call stack size exceeded.`

In my case, the file to parse was `session.json`; the file existed and was successfully read, however the error happened while calling JSON.parse()... After some digging I noticed an `\ufeff` character at the begginning of the file, so by doing a .trim() to the read content, it became parseable.

As an example, my content was kinda:  `'﻿\ufeff{"jwt":"JWT eyJas...`

In the end, I was able to get the extension to activate, sign in and use it as expected.